### PR TITLE
remove: Completely remove SkinsRestorer from the project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ bukkit {
             'ProtocolLib',
             'NextTestServer',
             'CMI',
-            'SkinsRestorer',
             'HolographicDisplays',
             'PlaceholderAPI',
             'Legendchat',


### PR DESCRIPTION
- Support for SkinsRestorer in NextEconomy has been removed, however, they forgot to remove it from gradle.